### PR TITLE
Accept unrecognized context URI schemes in OmlRead.getResolvedImportUri()

### DIFF
--- a/io.opencaesar.oml.parent/io.opencaesar.oml/src/io/opencaesar/oml/util/OmlRead.xtend
+++ b/io.opencaesar.oml.parent/io.opencaesar.oml/src/io/opencaesar/oml/util/OmlRead.xtend
@@ -100,6 +100,7 @@ import io.opencaesar.oml.VocabularyImport
 import io.opencaesar.oml.VocabularyStatement
 import io.opencaesar.oml.VocabularyUsage
 import java.io.File
+import java.net.MalformedURLException
 import java.net.URL
 import java.util.ArrayList
 import java.util.Collections
@@ -680,24 +681,28 @@ class OmlRead {
 					if (catalogMap === null) {
 						rs.loadOptions.put(CATALOGS, catalogMap = new HashMap<File, OmlCatalog>)
 					}
-        			val url = FileLocator.toFileURL(new URL(contextURI.trimSegments(1).toString()))
-        			val folder = new File(url.file);
-					if (!catalogMap.containsKey(folder)) {
-						catalogMap.findCatalogs(folder)
-					}
-					var catalog = catalogMap.get(folder)
-					if (catalog !== null) {
-						val resolved = catalog.resolveURI(uri.toString)
-						if (resolved !== null) {
-							uri = URI.createURI(resolved)
-							if (uri.fileExtension === null) {
-								// if the imported URI does not end with an extension, assume it's .oml
-								uri = uri.appendFileExtension(OML_EXTENSION)
-							} else if (NUMBER.matcher(uri.fileExtension).matches) { 
-								// special case for the dc vocabulary ending its IRI with a version number
-								uri = uri.appendFileExtension(OML_EXTENSION)
-							}					
+					try {
+						val url = FileLocator.toFileURL(new URL(contextURI.trimSegments(1).toString()))
+						val folder = new File(url.file);
+						if (!catalogMap.containsKey(folder)) {
+							catalogMap.findCatalogs(folder)
 						}
+						var catalog = catalogMap.get(folder)
+						if (catalog !== null) {
+							val resolved = catalog.resolveURI(uri.toString)
+							if (resolved !== null) {
+								uri = URI.createURI(resolved)
+								if (uri.fileExtension === null) {
+									// if the imported URI does not end with an extension, assume it's .oml
+									uri = uri.appendFileExtension(OML_EXTENSION)
+								} else if (NUMBER.matcher(uri.fileExtension).matches) {
+									// special case for the dc vocabulary ending its IRI with a version number
+									uri = uri.appendFileExtension(OML_EXTENSION)
+								}
+							}
+						}
+					} catch (MalformedURLException e) {
+						// the contextURI scheme is not recognized
 					}
 				}
 			}


### PR DESCRIPTION
If the resource URI of the ontology containing the import has an unrecognized scheme, the URL constructor throws a `MalformedURLException`. In that case, resolve to the URI as given in the import.