### PR TITLE
Fix OmlRead.findCatalogs() in Eclipse on Windows

### DIFF
--- a/io.opencaesar.oml/src/io/opencaesar/oml/util/OmlRead.java
+++ b/io.opencaesar.oml/src/io/opencaesar/oml/util/OmlRead.java
@@ -18,11 +18,11 @@
  */
 package io.opencaesar.oml.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -996,7 +996,7 @@ public class OmlRead {
 				System.out.println(e);
 			}
 			try {
-				if (catalogFileUrl != null && catalogFileUrl.getProtocol().equals("file") && Paths.get(catalogFileUrl.toURI()).toFile().exists()) {
+				if (catalogFileUrl != null && catalogFileUrl.getProtocol().equals("file") && new File(catalogFileUrl.getPath()).exists()) {
 					catalog = OmlCatalog.create(catalogUrl);
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
To convert Eclipse platform URLs to File objects, we were passing the converted file URLs from `FileLocator.toFileURL()` to `Paths.get()` and then converting the `Path` to a `File`, but on Windows the file URLs `FileLocator.toFileURL(`) returns are not accepted by `Paths.get()`. Instead, we now use the file URL path string to construct the `File`.