### PR TITLE
OML 2 Updater script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,15 @@
+# How to Use OML 2 Updater
+
+### This updater can work with any OML repo.
+
+1. Verify that you have Python 3 installed
+2. Can install using HomeBrew, Chocolatey, Scoop, or from the Python website: https://www.python.org/downloads/
+3. Assuming you are at the `root` of this repo, in any terminal run, `python oml2_updater.py <path_to_target_repo>`
+4. Example: `python oml2_updater.py ~/kepler16b`
+5. Then look for compile errors in *.oml files and manually do:
+6. Replace <type> XXX < YYY [ ... ] by <type> XXX [ ... ] < YYY
+7. Replace enumerated scalar XXX [ "yyy", "zzz", ... ] by scalar XXX [ oneOf "yyy", "zzz", ... ]
+8. Replace [ restricts ... ] by < [ restricts ... ]
+9. If there is a [ ... ] with restricts statements and other statements, separate them into different [ .. ] and put the restricts one after the < and the rest before the <
+10. Verify that you can run `./gradlew build` after updating the OML model to OML 2
+11. Look at https://www.opencaesar.io/projects/2023-7-21-OML-v2.html for more information 

--- a/scripts/oml2_updater.py
+++ b/scripts/oml2_updater.py
@@ -1,0 +1,49 @@
+import glob 
+import os
+import sys
+
+TARGET_REPO = sys.argv[1]
+
+# all oml, omlxmi, and velocity files and subfiles starting from the root of the current working directory
+FILES = glob.glob(os.path.join(TARGET_REPO, '**/*.oml'), recursive=True) + glob.glob(os.path.join(TARGET_REPO, '**/*.omlxmi'), recursive=True) + glob.glob(os.path.join(TARGET_REPO, '**/*.velocity'), recursive=True)
+
+# Don't update files within the build directory
+FILTERED_FILES = [i for i in FILES if "build" not in i]
+
+# Dictionary where the keys correspond to the OML 1 syntax and the values correspond to the OML 2 syntax
+OML2_SYNTAX = {
+    ':>': '<',
+    'ci ': 'instance ',
+    'ri ': 'relation instance ',
+    'ConceptTypeAssertion': 'TypeAssertion',
+    'RelationTypeAssertion': 'TypeAssertion',
+    'ScalarPropertyValueAssertion': 'PropertyValueAssertion',
+    'LinkAssertion': 'PropertyValueAssertion',
+    'FacetedScalar': 'Scalar',
+    '<value': '<literalValue',
+    '<ownedLinks': '<ownedPropertyValues',
+    '</ownedLinks': '</ownedPropertyValues',
+    '<relation': '<property',
+    '<target': '<referencedValue',
+    'target=': 'referencedValue=',
+    '<ownedImports xsi:type="oml:DescriptionUsage"': '<ownedImports xsi:type="oml:Import" kind="usage"',
+    '<ownedImports xsi:type="oml:DescriptionExtension"': '<ownedImports xsi:type="oml:Import" kind="extension"'
+}
+
+def update_files(old_str: str, new_str: str) -> None:
+    """ Updates files that contains old string with new string. """
+    for file in FILTERED_FILES:
+        if os.path.isfile(file):
+            print(file)
+            with open(file, 'r') as f:
+                content = f.read()
+                
+            content = content.replace(old_str, new_str)
+            
+            with open(file, 'w') as f: 
+                f.write(content)
+        
+if __name__ == '__main__':
+    for s in OML2_SYNTAX:
+        print(f"# Update {s} to {OML2_SYNTAX[s]}")
+        update_files(s, OML2_SYNTAX[s])


### PR DESCRIPTION
oml 2 updater script and README.md

**The script does not take care of all updates since some changes in the OML files require manually editing**

1. Replace <type> XXX < YYY [ ... ] by <type> XXX [ ... ] < YYY
2. Replace enumerated scalar XXX [ "yyy", "zzz", ... ] by scalar XXX [ oneOf "yyy", "zzz", ... ]
3. Replace [ restricts ... ] by < [ restricts ... ]
4. If there is a [ ... ] with restricts statements and other statements, separate them into different [ .. ] and put the restricts one after the < and the rest before the <
5. Verify that you can run `./gradlew build` after updating the OML model to OML 2